### PR TITLE
Remove fmt.Println in SaveMP3

### DIFF
--- a/mp3_encoder.go
+++ b/mp3_encoder.go
@@ -24,7 +24,6 @@ func SaveMP3(tag *MP3Tag, w io.Writer) error {
 		return err
 	}
 	originalSize := int64(mp3Tag.Size())
-	fmt.Println(originalSize)
 	for k, v := range mp3TextFrames {
 		if k == "DiscNumberString" {
 			textFrame := mp3TagLib.TextFrame{


### PR DESCRIPTION
Looks like this fmt.Println was accidentally left in the code, so this pull request removes it